### PR TITLE
Fix loss of running daily volume in sorting field workaround due to lack of significant digits

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -65,7 +65,7 @@ type FixedProductMarketMaker @entity {
   runningDailyVolume: BigInt!
   scaledRunningDailyVolume: BigDecimal!
   lastActiveDayAndRunningDailyVolume: BigInt!
-  lastActiveDayAndScaledRunningDailyVolume: BigDecimal!
+  lastActiveDayAndScaledRunningDailyVolume: BigInt!
 
   collateralVolumeBeforeLastActiveDay: BigInt!
 

--- a/src/FPMMDeterministicFactoryMapping.template.ts
+++ b/src/FPMMDeterministicFactoryMapping.template.ts
@@ -117,9 +117,10 @@ export function handleFixedProductMarketMakerCreation(event: FixedProductMarketM
   fixedProductMarketMaker.outcomeTokenAmounts = outcomeTokenAmounts;
   let liquidityParameter = nthRoot(amountsProduct, outcomeTokenAmounts.length);
   let collateralScale = getCollateralScale(fixedProductMarketMaker.collateralToken as Address);
-  updateLiquidityFields(fixedProductMarketMaker, liquidityParameter, collateralScale);
+  let collateralScaleDec = collateralScale.toBigDecimal();
+  updateLiquidityFields(fixedProductMarketMaker, liquidityParameter, collateralScaleDec);
 
-  updateScaledVolumes(fixedProductMarketMaker, collateralScale, currentDay);
+  updateScaledVolumes(fixedProductMarketMaker, collateralScale, collateralScaleDec, currentDay);
 
   fixedProductMarketMaker.save();
 

--- a/src/FixedProductMarketMakerMapping.ts
+++ b/src/FixedProductMarketMakerMapping.ts
@@ -57,7 +57,7 @@ export function handleFundingAdded(event: FPMMFundingAdded): void {
   fpmm.outcomeTokenAmounts = newAmounts;
   let liquidityParameter = nthRoot(amountsProduct, newAmounts.length);
   let collateralScale = getCollateralScale(fpmm.collateralToken as Address);
-  updateLiquidityFields(fpmm as FixedProductMarketMaker, liquidityParameter, collateralScale);
+  updateLiquidityFields(fpmm as FixedProductMarketMaker, liquidityParameter, collateralScale.toBigDecimal());
   fpmm.save();
 }
 
@@ -80,7 +80,7 @@ export function handleFundingRemoved(event: FPMMFundingRemoved): void {
   fpmm.outcomeTokenAmounts = newAmounts;
   let liquidityParameter = nthRoot(amountsProduct, newAmounts.length);
   let collateralScale = getCollateralScale(fpmm.collateralToken as Address);
-  updateLiquidityFields(fpmm as FixedProductMarketMaker, liquidityParameter, collateralScale);
+  updateLiquidityFields(fpmm as FixedProductMarketMaker, liquidityParameter, collateralScale.toBigDecimal());
   fpmm.save();
 }
 
@@ -109,7 +109,8 @@ export function handleBuy(event: FPMMBuy): void {
   fpmm.outcomeTokenAmounts = newAmounts;
   let liquidityParameter = nthRoot(amountsProduct, newAmounts.length);
   let collateralScale = getCollateralScale(fpmm.collateralToken as Address);
-  updateLiquidityFields(fpmm as FixedProductMarketMaker, liquidityParameter, collateralScale);
+  let collateralScaleDec = collateralScale.toBigDecimal();
+  updateLiquidityFields(fpmm as FixedProductMarketMaker, liquidityParameter, collateralScaleDec);
 
   let currentDay = timestampToDay(event.block.timestamp);
 
@@ -122,7 +123,7 @@ export function handleBuy(event: FPMMBuy): void {
   fpmm.runningDailyVolume = fpmm.collateralVolume.minus(fpmm.collateralVolumeBeforeLastActiveDay);
   fpmm.lastActiveDayAndRunningDailyVolume = joinDayAndVolume(currentDay, fpmm.runningDailyVolume);
 
-  updateScaledVolumes(fpmm as FixedProductMarketMaker, collateralScale, currentDay);
+  updateScaledVolumes(fpmm as FixedProductMarketMaker, collateralScale, collateralScaleDec, currentDay);
 
   fpmm.save();
 
@@ -153,7 +154,8 @@ export function handleSell(event: FPMMSell): void {
   fpmm.outcomeTokenAmounts = newAmounts;
   let liquidityParameter = nthRoot(amountsProduct, newAmounts.length);
   let collateralScale = getCollateralScale(fpmm.collateralToken as Address);
-  updateLiquidityFields(fpmm as FixedProductMarketMaker, liquidityParameter, collateralScale);
+  let collateralScaleDec = collateralScale.toBigDecimal();
+  updateLiquidityFields(fpmm as FixedProductMarketMaker, liquidityParameter, collateralScaleDec);
 
   let currentDay = timestampToDay(event.block.timestamp);
 
@@ -166,7 +168,7 @@ export function handleSell(event: FPMMSell): void {
   fpmm.runningDailyVolume = fpmm.collateralVolume.minus(fpmm.collateralVolumeBeforeLastActiveDay);
   fpmm.lastActiveDayAndRunningDailyVolume = joinDayAndVolume(currentDay, fpmm.runningDailyVolume);
 
-  updateScaledVolumes(fpmm as FixedProductMarketMaker, collateralScale, currentDay);
+  updateScaledVolumes(fpmm as FixedProductMarketMaker, collateralScale, collateralScaleDec, currentDay);
 
   fpmm.save();
 

--- a/src/day-volume-utils.ts
+++ b/src/day-volume-utils.ts
@@ -8,11 +8,14 @@ let twoPow256Bytes = new Uint8Array(33) as Bytes;
 twoPow256Bytes.fill(0);
 twoPow256Bytes[32] = 1;
 let twoPow256 = BigInt.fromUnsignedBytes(twoPow256Bytes);
+let scaledVolumeGranularity = BigInt.fromI32(1000000);
 
 export function joinDayAndVolume(day: BigInt, volume: BigInt): BigInt {
   return day.times(twoPow256).plus(volume);
 }
 
-export function joinDayAndScaledVolume(day: BigInt, scaledVolume: BigDecimal): BigDecimal {
-  return day.times(twoPow256).toBigDecimal().plus(scaledVolume);
+export function joinDayAndScaledVolume(day: BigInt, volume: BigInt, collateralScale: BigInt): BigInt {
+  return day.times(twoPow256).times(scaledVolumeGranularity).plus(
+    volume.times(scaledVolumeGranularity).div(collateralScale)
+  );
 }

--- a/src/fpmm-utils.ts
+++ b/src/fpmm-utils.ts
@@ -3,23 +3,29 @@ import { FixedProductMarketMaker } from "../generated/schema";
 import { ERC20Detailed } from "../generated/templates/ERC20Detailed/ERC20Detailed"
 import { joinDayAndScaledVolume } from './day-volume-utils';
 
-export function getCollateralScale(collateralTokenAddress: Address): BigDecimal {
+export function getCollateralScale(collateralTokenAddress: Address): BigInt {
   let collateralToken = ERC20Detailed.bind(collateralTokenAddress);
   let result = collateralToken.try_decimals();
 
   return result.reverted ?
-    BigInt.fromI32(1).toBigDecimal() :
-    BigInt.fromI32(10).pow(<u8>result.value).toBigDecimal();
+    BigInt.fromI32(1) :
+    BigInt.fromI32(10).pow(<u8>result.value);
 }
 
 export function updateScaledVolumes(
   fpmm: FixedProductMarketMaker,
-  collateralScale: BigDecimal,
+  collateralScale: BigInt,
+  collateralScaleDec: BigDecimal,
   currentDay: BigInt,
 ): void {
-  fpmm.scaledCollateralVolume = fpmm.collateralVolume.divDecimal(collateralScale);
-  fpmm.scaledRunningDailyVolume = fpmm.runningDailyVolume.divDecimal(collateralScale);
-  fpmm.lastActiveDayAndScaledRunningDailyVolume = joinDayAndScaledVolume(currentDay, fpmm.scaledRunningDailyVolume);
+  fpmm.scaledCollateralVolume = fpmm.collateralVolume.divDecimal(collateralScaleDec);
+  fpmm.scaledRunningDailyVolume = fpmm.runningDailyVolume.divDecimal(collateralScaleDec);
+  
+  fpmm.lastActiveDayAndScaledRunningDailyVolume = joinDayAndScaledVolume(
+    currentDay,
+    fpmm.runningDailyVolume,
+    collateralScale
+  );
 }
 
 export function updateLiquidityFields(


### PR DESCRIPTION
Should resolve #24 

Scales all collateral values in that field to the millionth's place while multiplying the upper part containing the last active day by 1000000. As long as the last active day isn't being read off of the combined sorting workaround value (which it shouldn't), everything should be working fine.

Will not distinguish volumes beyond a millionth of a token.