### PR TITLE
fix: incorrect `klerosTCRregistered` for markets with multiple submissions.

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -137,8 +137,7 @@ type FixedProductMarketMaker @entity {
   participants: [FpmmParticipation!] @derivedFrom(field: "fpmm")
 
   # Generalized TCR fields (Kleros Curate Contract for market verification)
-  klerosTCRitemID: String
-  klerosTCRstatus: Int
+  submissionIDs: [String!]!
   klerosTCRregistered: Boolean!
 
   curatedByDxDaoOrKleros: Boolean!
@@ -198,6 +197,12 @@ type Global @entity {
 
   usdPerEth: BigDecimal
   usdVolume: BigDecimal!
+}
+
+type MarketKleros @entity {
+  id: ID!
+  # status: String!
+  # listAddress: String!
 }
 
 type _Schema_

--- a/schema.graphql
+++ b/schema.graphql
@@ -137,7 +137,7 @@ type FixedProductMarketMaker @entity {
   participants: [FpmmParticipation!] @derivedFrom(field: "fpmm")
 
   # Generalized TCR fields (Kleros Curate Contract for market verification)
-  submissionIDs: [String!]!
+  submissionIDs: [MarketKleros!]! 
   klerosTCRregistered: Boolean!
 
   curatedByDxDaoOrKleros: Boolean!
@@ -201,8 +201,9 @@ type Global @entity {
 
 type MarketKleros @entity {
   id: ID!
-  # status: String!
-  # listAddress: String!
+  status: String!
+  listAddress: String!
+  market: FixedProductMarketMaker!
 }
 
 type _Schema_

--- a/schema.graphql
+++ b/schema.graphql
@@ -137,7 +137,7 @@ type FixedProductMarketMaker @entity {
   participants: [FpmmParticipation!] @derivedFrom(field: "fpmm")
 
   # Generalized TCR fields (Kleros Curate Contract for market verification)
-  submissionIDs: [MarketKleros!]! 
+  submissionIDs: [KlerosSubmission!]!
   klerosTCRregistered: Boolean!
 
   curatedByDxDaoOrKleros: Boolean!
@@ -199,9 +199,20 @@ type Global @entity {
   usdVolume: BigDecimal!
 }
 
-type MarketKleros @entity {
+enum KlerosStatus {
+  "The item is not registered on the TCR and there are no pending requests."
+  Absent
+  "The item is registered and there are no pending requests."
+  Registered
+  "The item is not registered on the TCR, but there is a pending registration request."
+  RegistrationRequested
+  "The item is registered on the TCR, but there is a pending removal request. These are sometimes also called removal requests."
+  ClearingRequested
+}
+
+type KlerosSubmission @entity {
   id: ID!
-  status: String!
+  status: KlerosStatus!
   listAddress: String!
   market: FixedProductMarketMaker!
 }

--- a/src/FPMMDeterministicFactoryMapping.template.ts
+++ b/src/FPMMDeterministicFactoryMapping.template.ts
@@ -55,6 +55,7 @@ export function handleFixedProductMarketMakerCreation(event: FixedProductMarketM
   fpmm.curatedByDxDao = false;
   fpmm.curatedByDxDaoOrKleros = false;
   fpmm.klerosTCRregistered = false;
+  fpmm.submissionIDs = []
 
   if(conditionIdStrs.length == 1) {
     let conditionIdStr = conditionIdStrs[0];

--- a/src/GeneralizedTCRMapping.ts
+++ b/src/GeneralizedTCRMapping.ts
@@ -73,8 +73,8 @@ export function handleItemStatusChange(event: ItemStatusChange): void {
 
   // Check if we are updating an entry or creating a new one.
   let newSubmission = true;
+  let submissionIDs = fpmm.submissionIDs;
   for (let i = 0; i < fpmm.submissionIDs.length; i++) {
-    let submissionIDs = fpmm.submissionIDs;
     let itemID = submissionIDs[i];
     let submission = KlerosSubmission.load(itemID);
     if (submission != null && submission.id == event.params._itemID.toHexString()) {
@@ -88,7 +88,6 @@ export function handleItemStatusChange(event: ItemStatusChange): void {
     currentSubmission.listAddress = event.address.toHexString();
     currentSubmission.market = fpmm.id;
 
-    let submissionIDs = fpmm.submissionIDs;
     submissionIDs.push(currentSubmission.id);
 
     fpmm.submissionIDs = submissionIDs;
@@ -103,7 +102,6 @@ export function handleItemStatusChange(event: ItemStatusChange): void {
   // set klerosTCRregistered = true. Set to false otherwise.
   fpmm.klerosTCRregistered = false;
   for (let i = 0; i < fpmm.submissionIDs.length; i++) {
-    let submissionIDs = fpmm.submissionIDs;
     let itemID = submissionIDs[i];
     let submission = KlerosSubmission.load(itemID);
 

--- a/src/GeneralizedTCRMapping.ts
+++ b/src/GeneralizedTCRMapping.ts
@@ -1,6 +1,6 @@
 import { log } from '@graphprotocol/graph-ts';
 import { ItemStatusChange, GeneralizedTCR } from '../generated/GeneralizedTCR/GeneralizedTCR';
-import { FixedProductMarketMaker } from '../generated/schema';
+import { FixedProductMarketMaker, MarketKleros } from '../generated/schema';
 
 function hexStringToLowerCase(input: string): string {
   // Code looks weird? Unfortunately the current version
@@ -26,46 +26,81 @@ function hexStringToLowerCase(input: string): string {
   return output
 }
 
-export function handleItemStatusChange(event: ItemStatusChange): void {
-  const tcr = GeneralizedTCR.bind(event.address);
-  const itemInfo = tcr.getItemInfo(event.params._itemID);
-  const decodedData = itemInfo.value0.toString()
+// Items on a TCR can be in 1 of 4 states:
+// - (0) Absent: The item is not registered on the TCR and there are no pending requests.
+// - (1) Registered: The item is registered and there are no pending requests.
+// - (2) Registration Requested: The item is not registered on the TCR, but there is a pending
+//       registration request.
+// - (3) Clearing Requested: The item is registered on the TCR, but there is a pending removal
+//       request. These are sometimes also called removal requests.
+//
+// Registration and removal requests can be challenged. Once the request resolves (either by
+// passing the challenge period or via dispute resolution), the item state is updated to 0 or 1.
 
-  const addressStartIndex = decodedData.lastIndexOf('0x')
+let ABSENT = "Absent";
+let REGISTERED = "Registered";
+let REGISTRATION_REQUESTED = "RegistrationRequested";
+let CLEARING_REQUESTED = "ClearingRequested";
+
+function getStatus(status: number): string {
+  if (status == 0) return ABSENT;
+  if (status == 1) return REGISTERED;
+  if (status == 2) return REGISTRATION_REQUESTED;
+  if (status == 3) return CLEARING_REQUESTED;
+  return "Error";
+}
+
+export function handleItemStatusChange(event: ItemStatusChange): void {
+  log.info('GTCR: handleItemStatusChange for {} started', [event.params._itemID.toHexString()]);
+  let tcr = GeneralizedTCR.bind(event.address);
+  let itemInfo = tcr.getItemInfo(event.params._itemID);
+  let decodedData = itemInfo.value0.toString();
+
+  let addressStartIndex = decodedData.lastIndexOf('0x');
   if (addressStartIndex == -1) {
-    log.warning('GTCR: No address found for itemID {} ', [event.params._itemID.toHexString()])
+    log.warning('GTCR: No address found for itemID {}.', [event.params._itemID.toHexString()]);
     return // Invalid submission. No Op
   }
-  const fpmmAddress = decodedData.slice(addressStartIndex, addressStartIndex + 42)
+  let fpmmAddress = decodedData.slice(addressStartIndex, addressStartIndex + 42);
 
   // Workaround missing String.toLowerCase function in assemblyscript.
-  const lowerCaseFpmmAddr = hexStringToLowerCase(fpmmAddress)
+  let lowerCaseFpmmAddr = hexStringToLowerCase(fpmmAddress);
 
   let fpmm = FixedProductMarketMaker.load(lowerCaseFpmmAddr);
   if (fpmm == null) {
-    log.warning("GTCR: Could not load FPMM for {}", [lowerCaseFpmmAddr]);
+    log.warning("GTCR: Could not load FPMM for {}.", [lowerCaseFpmmAddr]);
     return;
+  }  
+
+  let submissionsCount = fpmm.submissionIDs.length;
+  let submissionIndex = -1;  
+  log.info('GTCR: Searching for submission. {} submissions for this market', [submissionsCount.toString()]);
+  for (let i = 0; i < fpmm.submissionIDs.length; i++) {
+    log.info('GTCR: {} of {}.', [(i + 1).toString(), submissionsCount.toString()]);
+    let submissionIDs = fpmm.submissionIDs;
+    let itemID = submissionIDs[i];
+    let submission = MarketKleros.load(itemID);
+    if (submission != null) {
+      // log.info('GTCR: loaded submission', []);
+      if (submission.id == event.params._itemID.toHexString()) {
+        // log.info('GTCR: found submission', []);
+        submissionIndex = i;
+      }
+    }   
   }
 
-  // Items on a TCR can be in 1 of 4 states:
-  // - (0) Absent: The item is not registered on the TCR and there are no pending requests.
-  // - (1) Registered: The item is registered and there are no pending requests.
-  // - (2) Registration Requested: The item is not registered on the TCR, but there is a pending
-  //       registration request.
-  // - (3) Removal Requested: The item is registered on the TCR, but there is a pending removal
-  //       request.
-  //
-  // Registration and Removal requests can be challenged. Once the request resolves (either by
-  // passing the challenge period or via dispute resolution), the item state is updated to 0 or 1.
+  if (submissionIndex == -1) {
+    let submission = new MarketKleros(event.params._itemID.toHexString()); 
+    submission.save();
+    
+    let submissionIDs = fpmm.submissionIDs;
+    submissionIDs.push(submission.id);
 
-  const REGISTERED = 1;
-  const REMOVAL_REQUESTED = 3;
-
-  fpmm.klerosTCRitemID = event.params._itemID.toHexString();
-  fpmm.klerosTCRstatus = itemInfo.value1;
-  fpmm.klerosTCRregistered = fpmm.klerosTCRstatus == REGISTERED || fpmm.klerosTCRstatus == REMOVAL_REQUESTED;
-  fpmm.curatedByDxDaoOrKleros = fpmm.klerosTCRregistered == true || fpmm.curatedByDxDao == true;
-  fpmm.save();
+    fpmm.submissionIDs = submissionIDs;
+    log.info('GTCR: Submission not found. Created one. ID: {}, {}', [submission.id, event.params._itemID.toHexString()]);
+  }
+  
+  fpmm.save();  
 }
 
 

--- a/test/omen-subgraph.js
+++ b/test/omen-subgraph.js
@@ -675,13 +675,12 @@ describe('Omen subgraph', function() {
 
     await advanceBlock()
     await waitForGraphSync();
-    expect((await querySubgraph(`{
-      fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
-        klerosTCRregistered
-        klerosTCRstatus
-        curatedByDxDaoOrKleros
-      }
-    }`)).fixedProductMarketMaker).to.deep.equal({ klerosTCRregistered: false, klerosTCRstatus: REGISTRATION_REQUESTED, curatedByDxDaoOrKleros: false })
+    // expect((await querySubgraph(`{
+    //   fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
+    //     klerosTCRregistered
+    //     curatedByDxDaoOrKleros
+    //   }
+    // }`)).fixedProductMarketMaker).to.deep.equal({ klerosTCRregistered: false, curatedByDxDaoOrKleros: false })
 
     await increaseTime(1)
     const itemID = await marketsTCR.itemList(0)
@@ -689,50 +688,46 @@ describe('Omen subgraph', function() {
 
     await advanceBlock()
     await waitForGraphSync();
-    expect((await querySubgraph(`{
-      fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
-        klerosTCRregistered
-        klerosTCRstatus
-        curatedByDxDaoOrKleros
-      }
-    }`)).fixedProductMarketMaker).to.deep.equal({ klerosTCRregistered: false, klerosTCRstatus: REGISTRATION_REQUESTED, curatedByDxDaoOrKleros: false })
+    // expect((await querySubgraph(`{
+    //   fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
+    //     klerosTCRregistered
+    //     curatedByDxDaoOrKleros
+    //   }
+    // }`)).fixedProductMarketMaker).to.deep.equal({ klerosTCRregistered: false, curatedByDxDaoOrKleros: false })
 
     const [ACCEPT, REJECT] = [1, 2] // Possible rulings
     await centralizedArbitrator.rule(0, ACCEPT, { from: creator })
 
     await advanceBlock()
     await waitForGraphSync();
-    expect((await querySubgraph(`{
-      fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
-        klerosTCRregistered
-        klerosTCRstatus
-        curatedByDxDaoOrKleros
-      }
-    }`)).fixedProductMarketMaker).to.deep.equal({ klerosTCRregistered: true, klerosTCRstatus: REGISTERED, curatedByDxDaoOrKleros: true })
+    // expect((await querySubgraph(`{
+    //   fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
+    //     klerosTCRregistered
+    //     curatedByDxDaoOrKleros
+    //   }
+    // }`)).fixedProductMarketMaker).to.deep.equal({ klerosTCRregistered: true, curatedByDxDaoOrKleros: true })    
 
     increaseTime(10)
     await marketsTCR.removeItem(itemID, '', { from: creator, value: arbitrationCost })
     await advanceBlock()
     await waitForGraphSync();
-    expect((await querySubgraph(`{
-      fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
-        klerosTCRregistered
-        klerosTCRstatus
-        curatedByDxDaoOrKleros
-      }
-    }`)).fixedProductMarketMaker).to.deep.equal({ klerosTCRregistered: true, klerosTCRstatus: REMOVAL_REQUESTED, curatedByDxDaoOrKleros: true })
+    // expect((await querySubgraph(`{
+    //   fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
+    //     klerosTCRregistered
+    //     curatedByDxDaoOrKleros
+    //   }
+    // }`)).fixedProductMarketMaker).to.deep.equal({ klerosTCRregistered: true, curatedByDxDaoOrKleros: true })
 
     increaseTime(10)
     await marketsTCR.executeRequest(itemID, { from: creator })
     await advanceBlock()
     await waitForGraphSync();
-    expect((await querySubgraph(`{
-      fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
-        klerosTCRregistered
-        klerosTCRstatus
-        curatedByDxDaoOrKleros
-      }
-    }`)).fixedProductMarketMaker).to.deep.equal({ klerosTCRregistered: false, klerosTCRstatus: ABSENT, curatedByDxDaoOrKleros: false })
+    // expect((await querySubgraph(`{
+    //   fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
+    //     klerosTCRregistered
+    //     curatedByDxDaoOrKleros
+    //   }
+    // }`)).fixedProductMarketMaker).to.deep.equal({ klerosTCRregistered: true, curatedByDxDaoOrKleros: true })
 
     // DXTokenRegistryMapping only handles AddToken for the 4th list.
     // Add some lists.
@@ -744,22 +739,46 @@ describe('Omen subgraph', function() {
     await dxTokenRegistry.addTokens(4, [fpmm.address], { from: creator })
     await advanceBlock()
     await waitForGraphSync();
-    expect((await querySubgraph(`{
-      fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
-        curatedByDxDaoOrKleros
-        curatedByDxDao
-      }
-    }`)).fixedProductMarketMaker).to.deep.equal({ curatedByDxDaoOrKleros: true, curatedByDxDao: true })
+    // expect((await querySubgraph(`{
+    //   fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
+    //     curatedByDxDaoOrKleros
+    //     curatedByDxDao
+    //   }
+    // }`)).fixedProductMarketMaker).to.deep.equal({ curatedByDxDaoOrKleros: true, curatedByDxDao: true })
 
     await dxTokenRegistry.removeTokens(4, [fpmm.address], { from: creator })
     await advanceBlock()
     await waitForGraphSync();
-    expect((await querySubgraph(`{
-      fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
-        curatedByDxDaoOrKleros
-        curatedByDxDao
-      }
-    }`)).fixedProductMarketMaker).to.deep.equal({ curatedByDxDaoOrKleros: false, curatedByDxDao: false })
+    // expect((await querySubgraph(`{
+    //   fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
+    //     curatedByDxDaoOrKleros
+    //     curatedByDxDao
+    //   }
+    // }`)).fixedProductMarketMaker).to.deep.equal({ curatedByDxDaoOrKleros: false, curatedByDxDao: false })
 
+    // Test that having one market is enough for klerosTCRregistered to be true.
+    await marketsTCR.addItem(gtcrEncode({ columns, values: marketData }), { from: creator, value: arbitrationCost})
+    const marketBData = {
+      Question: 'Will Ethereum 2.0 Phase 0 launch before 2021?',
+      'Market URL':`https://omen.eth.link/#/${fpmm.address}`
+    }
+    await marketsTCR.addItem(gtcrEncode({ columns, values: marketBData }), { from: creator, value: arbitrationCost})
+    increaseTime(10)
+    await marketsTCR.executeRequest(itemID, { from: creator })
+    const itemIDB = await marketsTCR.itemList(1)
+    await marketsTCR.executeRequest(itemIDB, { from: creator })
+
+    await marketsTCR.removeItem(itemIDB, '', { from: creator, value: arbitrationCost })
+    increaseTime(10)
+    await marketsTCR.executeRequest(itemIDB, { from: creator })
+
+    await advanceBlock()
+    await waitForGraphSync();
+    // expect((await querySubgraph(`{
+    //   fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
+    //     klerosTCRregistered
+    //     curatedByDxDaoOrKleros
+    //   }
+    // }`)).fixedProductMarketMaker).to.deep.equal({ klerosTCRregistered: true, curatedByDxDaoOrKleros: true })
   })
 });

--- a/test/omen-subgraph.js
+++ b/test/omen-subgraph.js
@@ -669,18 +669,16 @@ describe('Omen subgraph', function() {
     }
 
     const arbitrationCost = await centralizedArbitrator.arbitrationCost('0x00')
-    await marketsTCR.addItem(gtcrEncode({ columns, values: marketData }), { from: creator, value: arbitrationCost})
-
-    const [ABSENT, REGISTERED, REGISTRATION_REQUESTED, REMOVAL_REQUESTED] = [0, 1, 2, 3]
+    await marketsTCR.addItem(gtcrEncode({ columns, values: marketData }), { from: creator, value: arbitrationCost })
 
     await advanceBlock()
     await waitForGraphSync();
-    // expect((await querySubgraph(`{
-    //   fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
-    //     klerosTCRregistered
-    //     curatedByDxDaoOrKleros
-    //   }
-    // }`)).fixedProductMarketMaker).to.deep.equal({ klerosTCRregistered: false, curatedByDxDaoOrKleros: false })
+    expect((await querySubgraph(`{
+      fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
+        klerosTCRregistered
+        curatedByDxDaoOrKleros
+      }
+    }`)).fixedProductMarketMaker).to.deep.equal({ klerosTCRregistered: false, curatedByDxDaoOrKleros: false })
 
     await increaseTime(1)
     const itemID = await marketsTCR.itemList(0)
@@ -688,46 +686,48 @@ describe('Omen subgraph', function() {
 
     await advanceBlock()
     await waitForGraphSync();
-    // expect((await querySubgraph(`{
-    //   fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
-    //     klerosTCRregistered
-    //     curatedByDxDaoOrKleros
-    //   }
-    // }`)).fixedProductMarketMaker).to.deep.equal({ klerosTCRregistered: false, curatedByDxDaoOrKleros: false })
+    expect((await querySubgraph(`{
+      fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
+        klerosTCRregistered
+        curatedByDxDaoOrKleros
+      }
+    }`)).fixedProductMarketMaker).to.deep.equal({ klerosTCRregistered: false, curatedByDxDaoOrKleros: false })
 
     const [ACCEPT, REJECT] = [1, 2] // Possible rulings
     await centralizedArbitrator.rule(0, ACCEPT, { from: creator })
 
     await advanceBlock()
     await waitForGraphSync();
-    // expect((await querySubgraph(`{
-    //   fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
-    //     klerosTCRregistered
-    //     curatedByDxDaoOrKleros
-    //   }
-    // }`)).fixedProductMarketMaker).to.deep.equal({ klerosTCRregistered: true, curatedByDxDaoOrKleros: true })    
+    expect((await querySubgraph(`{
+      fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
+        klerosTCRregistered
+        curatedByDxDaoOrKleros
+      }
+    }`)).fixedProductMarketMaker).to.deep.equal({ klerosTCRregistered: true, curatedByDxDaoOrKleros: true })
 
     increaseTime(10)
     await marketsTCR.removeItem(itemID, '', { from: creator, value: arbitrationCost })
     await advanceBlock()
     await waitForGraphSync();
-    // expect((await querySubgraph(`{
-    //   fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
-    //     klerosTCRregistered
-    //     curatedByDxDaoOrKleros
-    //   }
-    // }`)).fixedProductMarketMaker).to.deep.equal({ klerosTCRregistered: true, curatedByDxDaoOrKleros: true })
+    expect((await querySubgraph(`{
+      fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
+        klerosTCRregistered
+        curatedByDxDaoOrKleros
+        curatedByDxDao
+      }
+    }`)).fixedProductMarketMaker).to.deep.equal({ klerosTCRregistered: true, curatedByDxDaoOrKleros: true, curatedByDxDao: false })
 
     increaseTime(10)
     await marketsTCR.executeRequest(itemID, { from: creator })
     await advanceBlock()
     await waitForGraphSync();
-    // expect((await querySubgraph(`{
-    //   fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
-    //     klerosTCRregistered
-    //     curatedByDxDaoOrKleros
-    //   }
-    // }`)).fixedProductMarketMaker).to.deep.equal({ klerosTCRregistered: true, curatedByDxDaoOrKleros: true })
+    expect((await querySubgraph(`{
+      fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
+        klerosTCRregistered
+        curatedByDxDaoOrKleros
+        curatedByDxDao
+      }
+    }`)).fixedProductMarketMaker).to.deep.equal({ klerosTCRregistered: false, curatedByDxDaoOrKleros: false, curatedByDxDao: false })
 
     // DXTokenRegistryMapping only handles AddToken for the 4th list.
     // Add some lists.
@@ -739,22 +739,24 @@ describe('Omen subgraph', function() {
     await dxTokenRegistry.addTokens(4, [fpmm.address], { from: creator })
     await advanceBlock()
     await waitForGraphSync();
-    // expect((await querySubgraph(`{
-    //   fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
-    //     curatedByDxDaoOrKleros
-    //     curatedByDxDao
-    //   }
-    // }`)).fixedProductMarketMaker).to.deep.equal({ curatedByDxDaoOrKleros: true, curatedByDxDao: true })
+    expect((await querySubgraph(`{
+      fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
+        curatedByDxDaoOrKleros
+        curatedByDxDao
+        klerosTCRregistered
+      }
+    }`)).fixedProductMarketMaker).to.deep.equal({ curatedByDxDaoOrKleros: true, curatedByDxDao: true, klerosTCRregistered: false })
 
     await dxTokenRegistry.removeTokens(4, [fpmm.address], { from: creator })
     await advanceBlock()
     await waitForGraphSync();
-    // expect((await querySubgraph(`{
-    //   fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
-    //     curatedByDxDaoOrKleros
-    //     curatedByDxDao
-    //   }
-    // }`)).fixedProductMarketMaker).to.deep.equal({ curatedByDxDaoOrKleros: false, curatedByDxDao: false })
+    expect((await querySubgraph(`{
+      fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
+        curatedByDxDaoOrKleros
+        curatedByDxDao
+        klerosTCRregistered
+      }
+    }`)).fixedProductMarketMaker).to.deep.equal({ curatedByDxDaoOrKleros: false, curatedByDxDao: false, klerosTCRregistered: false })
 
     // Test that having one market is enough for klerosTCRregistered to be true.
     await marketsTCR.addItem(gtcrEncode({ columns, values: marketData }), { from: creator, value: arbitrationCost})
@@ -774,11 +776,11 @@ describe('Omen subgraph', function() {
 
     await advanceBlock()
     await waitForGraphSync();
-    // expect((await querySubgraph(`{
-    //   fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
-    //     klerosTCRregistered
-    //     curatedByDxDaoOrKleros
-    //   }
-    // }`)).fixedProductMarketMaker).to.deep.equal({ klerosTCRregistered: true, curatedByDxDaoOrKleros: true })
+    expect((await querySubgraph(`{
+      fixedProductMarketMaker(id: "${fpmm.address.toLowerCase()}") {
+        klerosTCRregistered
+        curatedByDxDaoOrKleros
+      }
+    }`)).fixedProductMarketMaker).to.deep.equal({ klerosTCRregistered: true, curatedByDxDaoOrKleros: true })
   })
 });


### PR DESCRIPTION
The current version of the GeneralizedTCRMapping does not properly handle the case where there are multiple submissions made to omen verified markets. Depending on the ordering of events (i.e. if a submission is rejected after another submission for the same market is accepted, the market gets marked as unverified).

This PR makes it so `klerosTCRregistered` will be set to true if there is at least one accepted submission.

> In case you are curious, we allow multiple submissions for the same item on curate to prevent griefing attacks.