### PR TITLE
Fix Omen Verified Markets on Rinkeby

### DIFF
--- a/networks.json
+++ b/networks.json
@@ -65,8 +65,8 @@
       "transactionHash": "0xc448229557e607473029fb5e88f367fc4f7c2b24a02ea6838a6b8cf58b5383eb"
     },
     "4": {
-      "address": "0x58574aF265E1feC3b2B6dD005CA17af8eDa581cc",
-      "transactionHash": "0xe559e5527507fd37f53d8491a346af6eac0adb691fb8370b5c7fd6a8cfc58074"
+      "address": "0x3b29096b7ab49428923d902cec3dfeaa49993234",
+      "transactionHash": "0xacf470108451380ddbc969e1f3aecd3e86c7eb4fa9140530358d14254dd53f65"
     }
   },
   "UniswapV2Factory": {


### PR DESCRIPTION
The previous version of the list used a buggy centralized arbitrator. This fixes the issue.