### PR TITLE
Add FPMM Liquidity entity

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/protofire/omen-subgraph.git"
-  },
-  "author": "Gnosis (https://gnosis.io)",
+    "url": "git+https://github.com/protofire/omen-subgrapht"
+  },": "Gnosis (https://gnosis.io)",
   "license": "LGPL-3.0",
   "bugs": {
     "url": "https://github.com/protofire/omen-subgraph/issues"

--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/protofire/omen-subgrapht"
-  },": "Gnosis (https://gnosis.io)",
+    "url": "git+https://github.com/protofire/omen-subgraph.git"
+  },
+  "author": "Gnosis (https://gnosis.io)",
   "license": "LGPL-3.0",
   "bugs": {
     "url": "https://github.com/protofire/omen-subgraph/issues"

--- a/schema.graphql
+++ b/schema.graphql
@@ -215,7 +215,7 @@ type FpmmLiquidity @entity {
   fpmm: FixedProductMarketMaker!
   type: LiquidityType!
   outcomeTokenAmounts: [BigInt!]
-  collateralTokenAmounts: BigInt!
+  collateralTokenAmount: BigInt!
   funder: Account!
   sharesAmount: BigInt!
   collateralRemovedFromFeePool: BigInt

--- a/schema.graphql
+++ b/schema.graphql
@@ -199,6 +199,7 @@ type FpmmTrade @entity {
   creator: Account!
   creationTimestamp: BigInt!
   collateralAmount: BigInt!
+  collateralAmountUSD: BigDecimal!
   feeAmount: BigInt!
   outcomeIndex: BigInt!
   outcomeTokensTraded: BigInt!

--- a/schema.graphql
+++ b/schema.graphql
@@ -187,6 +187,11 @@ enum TradeType {
   Sell
 }
 
+enum LiquidityType {
+  Add
+  Remove
+}
+
 type FpmmTrade @entity {
   id: ID!
   fpmm: FixedProductMarketMaker!
@@ -203,6 +208,18 @@ type FpmmTrade @entity {
   feeAmount: BigInt!
   outcomeIndex: BigInt!
   outcomeTokensTraded: BigInt!
+}
+
+type FpmmLiquidity @entity {
+  id: ID!
+  fpmm: FixedProductMarketMaker!
+  type: LiquidityType!
+  outcomeTokenAmounts: [BigInt!]
+  collateralTokenAmounts: BigInt!
+  funder: Account!
+  sharesAmount: BigInt!
+  collateralRemovedFromFeePool: BigInt
+  creationTimestamp: BigInt! 
 }
 
 type Account @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -216,6 +216,7 @@ type FpmmLiquidity @entity {
   type: LiquidityType!
   outcomeTokenAmounts: [BigInt!]
   collateralTokenAmount: BigInt!
+  additionalLiquidityParameter: BigInt!
   funder: Account!
   sharesAmount: BigInt!
   collateralRemovedFromFeePool: BigInt

--- a/src/FixedProductMarketMakerMapping.ts
+++ b/src/FixedProductMarketMakerMapping.ts
@@ -21,6 +21,7 @@ import { joinDayAndVolume } from './utils/day-volume';
 import { updateScaledVolumes, calculateLiquidityParameter, setLiquidity } from './utils/fpmm';
 import { requireToken } from './utils/token';
 import { requireGlobal } from './utils/global';
+import { max, min } from './utils/math';
 
 const TRADE_TYPE_BUY = "Buy";
 const TRADE_TYPE_SELL = "Sell";
@@ -89,7 +90,12 @@ function recordFPMMLiquidity(fpmm: FixedProductMarketMaker,
     fpmmLiquidity.creationTimestamp = creationTimestamp;
 
     fpmmLiquidity.outcomeTokenAmounts = outcomeTokenAmounts;
-    fpmmLiquidity.collateralTokenAmount = calculateLiquidityParameter(outcomeTokenAmounts);
+    if (liquidityType === LIQUIDITY_TYPE_ADD) {
+      fpmmLiquidity.collateralTokenAmount = max(outcomeTokenAmounts);
+    } else {
+      fpmmLiquidity.collateralTokenAmount = min(outcomeTokenAmounts);
+    }
+    fpmmLiquidity.additionalLiquidityParameter = calculateLiquidityParameter(outcomeTokenAmounts);
 
     fpmmLiquidity.sharesAmount = sharesAmount;
     fpmmLiquidity.collateralRemovedFromFeePool = collateralRemovedFromFeePool;

--- a/src/FixedProductMarketMakerMapping.ts
+++ b/src/FixedProductMarketMakerMapping.ts
@@ -271,12 +271,12 @@ export function handleBuy(event: FPMMBuy): void {
   let collateralScaleDec = collateralScale.toBigDecimal();
   let ethPerCollateral = collateral.ethPerToken;
   let usdPerEth = global.usdPerEth;
-  let collateralUSDPrice = ethPerCollateral != null && usdPerEth != null ?
-    ethPerCollateral.times(usdPerEth as BigDecimal) :
-    zeroDec;
-  let collateralAmountUSD = (collateralUSDPrice != zeroDec) ?
-    collateralUSDPrice.times(event.params.investmentAmount.divDecimal(collateralScaleDec)) :
-    zeroDec;
+  let collateralUSDPrice = zeroDec;
+  let collateralAmountUSD = zeroDec;
+  if (ethPerCollateral != null && usdPerEth != null) {
+    collateralUSDPrice = ethPerCollateral.times(usdPerEth as BigDecimal);
+    collateralAmountUSD = collateralUSDPrice.times(event.params.investmentAmount.divDecimal(collateralScaleDec));
+  }
 
   setLiquidity(fpmm as FixedProductMarketMaker, newAmounts, collateralScaleDec, collateralUSDPrice);
   increaseVolume(
@@ -328,12 +328,12 @@ export function handleSell(event: FPMMSell): void {
   let collateralScaleDec = collateralScale.toBigDecimal();
   let ethPerCollateral = collateral.ethPerToken;
   let usdPerEth = global.usdPerEth;
-  let collateralUSDPrice = ethPerCollateral != null && usdPerEth != null ?
-    ethPerCollateral.times(usdPerEth as BigDecimal) :
-    zeroDec;
-  let collateralAmountUSD = (collateralUSDPrice != zeroDec) ?
-   collateralUSDPrice.times(event.params.returnAmount.divDecimal(collateralScaleDec)) :
-   zeroDec;
+  let collateralUSDPrice = zeroDec;
+  let collateralAmountUSD = zeroDec;
+  if (ethPerCollateral != null && usdPerEth != null) {
+    collateralUSDPrice = ethPerCollateral.times(usdPerEth as BigDecimal);
+    collateralAmountUSD = collateralUSDPrice.times(event.params.returnAmount.divDecimal(collateralScaleDec));
+  }
 
   setLiquidity(fpmm as FixedProductMarketMaker, newAmounts, collateralScaleDec, collateralUSDPrice);
   increaseVolume(

--- a/src/FixedProductMarketMakerMapping.ts
+++ b/src/FixedProductMarketMakerMapping.ts
@@ -89,7 +89,7 @@ function recordFPMMLiquidity(fpmm: FixedProductMarketMaker,
     fpmmLiquidity.creationTimestamp = creationTimestamp;
 
     fpmmLiquidity.outcomeTokenAmounts = outcomeTokenAmounts;
-    fpmmLiquidity.collateralTokenAmounts = calculateLiquidityParameter(outcomeTokenAmounts);
+    fpmmLiquidity.collateralTokenAmount = calculateLiquidityParameter(outcomeTokenAmounts);
 
     fpmmLiquidity.sharesAmount = sharesAmount;
     fpmmLiquidity.collateralRemovedFromFeePool = collateralRemovedFromFeePool;

--- a/src/FixedProductMarketMakerMapping.ts
+++ b/src/FixedProductMarketMakerMapping.ts
@@ -7,6 +7,7 @@ import {
   FpmmParticipation,
   Global,
   FpmmTrade,
+  FpmmLiquidity,
 } from "../generated/schema"
 import {
   FPMMFundingAdded,
@@ -17,12 +18,14 @@ import {
 } from "../generated/templates/FixedProductMarketMaker/FixedProductMarketMaker"
 import { secondsPerHour, hoursPerDay, zero, zeroDec } from './utils/constants';
 import { joinDayAndVolume } from './utils/day-volume';
-import { updateScaledVolumes, setLiquidity } from './utils/fpmm';
+import { updateScaledVolumes, calculateLiquidityParameter, setLiquidity } from './utils/fpmm';
 import { requireToken } from './utils/token';
 import { requireGlobal } from './utils/global';
 
 const TRADE_TYPE_BUY = "Buy";
 const TRADE_TYPE_SELL = "Sell";
+const LIQUIDITY_TYPE_ADD = "Add";
+const LIQUIDITY_TYPE_REMOVE = "Remove";
 
 function requireAccount(accountAddress: string): Account | null {
   let account = Account.load(accountAddress);
@@ -62,6 +65,37 @@ function recordTrade(fpmm: FixedProductMarketMaker,
 
     fpmmTrade.save();
   }
+
+}
+
+function recordFPMMLiquidity(fpmm: FixedProductMarketMaker, 
+    liquidityType: string,
+    outcomeTokenAmounts: BigInt[],
+    funder: string,
+    sharesAmount: BigInt,
+    collateralRemovedFromFeePool: BigInt,
+    creationTimestamp: BigInt): void {
+  let account = requireAccount(funder);
+  account.tradeNonce = account.tradeNonce.plus(BigInt.fromI32(1));
+  account.save();
+
+  let fpmmLiquidityId = fpmm.id.concat(funder).concat(account.tradeNonce.toHexString());
+  let fpmmLiquidity = FpmmLiquidity.load(fpmmLiquidityId);
+  if (fpmmLiquidity == null) {
+    fpmmLiquidity = new FpmmLiquidity(fpmmLiquidityId);
+    fpmmLiquidity.fpmm = fpmm.id;
+    fpmmLiquidity.type = liquidityType;
+    fpmmLiquidity.funder = funder;
+    fpmmLiquidity.creationTimestamp = creationTimestamp;
+
+    fpmmLiquidity.outcomeTokenAmounts = outcomeTokenAmounts;
+    fpmmLiquidity.collateralTokenAmounts = calculateLiquidityParameter(outcomeTokenAmounts);
+
+    fpmmLiquidity.sharesAmount = sharesAmount;
+    fpmmLiquidity.collateralRemovedFromFeePool = collateralRemovedFromFeePool;
+
+    fpmmLiquidity.save();
+  }  
 
 }
 
@@ -214,6 +248,14 @@ export function handleFundingAdded(event: FPMMFundingAdded): void {
   setLiquidity(fpmm as FixedProductMarketMaker, newAmounts, collateralScaleDec, collateralUSDPrice)
 
   fpmm.save();
+
+  recordFPMMLiquidity(fpmm as FixedProductMarketMaker, 
+    LIQUIDITY_TYPE_ADD,
+    event.params.amountsAdded,
+    event.params.funder.toHexString(),
+    event.params.sharesMinted,
+    new BigInt(0),
+    event.block.timestamp);
 }
 
 export function handleFundingRemoved(event: FPMMFundingRemoved): void {
@@ -243,6 +285,14 @@ export function handleFundingRemoved(event: FPMMFundingRemoved): void {
   setLiquidity(fpmm as FixedProductMarketMaker, newAmounts, collateralScaleDec, collateralUSDPrice);
 
   fpmm.save();
+
+  recordFPMMLiquidity(fpmm as FixedProductMarketMaker, 
+    LIQUIDITY_TYPE_REMOVE,
+    event.params.amountsRemoved,
+    event.params.funder.toHexString(),
+    event.params.sharesBurnt,
+    event.params.collateralRemovedFromFeePool,
+    event.block.timestamp);
 }
 
 export function handleBuy(event: FPMMBuy): void {

--- a/src/FixedProductMarketMakerMapping.ts
+++ b/src/FixedProductMarketMakerMapping.ts
@@ -260,7 +260,7 @@ export function handleFundingAdded(event: FPMMFundingAdded): void {
     event.params.amountsAdded,
     event.params.funder.toHexString(),
     event.params.sharesMinted,
-    new BigInt(0),
+    BigInt.fromI32(0),
     event.block.timestamp);
 }
 

--- a/src/FixedProductMarketMakerMapping.ts
+++ b/src/FixedProductMarketMakerMapping.ts
@@ -35,7 +35,8 @@ function requireAccount(accountAddress: string): Account | null {
 }
 
 function recordTrade(fpmm: FixedProductMarketMaker, 
-    traderAddress: string, collateralAmount: BigInt,
+    traderAddress: string,
+    collateralAmount: BigInt, collateralAmountUSD: BigDecimal,
     feeAmount: BigInt, outcomeIndex: BigInt,
     outcomeTokensTraded: BigInt, tradeType: string,
     creationTimestamp: BigInt): void {
@@ -54,6 +55,7 @@ function recordTrade(fpmm: FixedProductMarketMaker,
     fpmmTrade.creator = traderAddress;
     fpmmTrade.creationTimestamp = creationTimestamp;
     fpmmTrade.collateralAmount = collateralAmount;
+    fpmmTrade.collateralAmountUSD = collateralAmountUSD;
     fpmmTrade.feeAmount = feeAmount;
     fpmmTrade.outcomeIndex = outcomeIndex;
     fpmmTrade.outcomeTokensTraded = outcomeTokensTraded;
@@ -272,6 +274,9 @@ export function handleBuy(event: FPMMBuy): void {
   let collateralUSDPrice = ethPerCollateral != null && usdPerEth != null ?
     ethPerCollateral.times(usdPerEth as BigDecimal) :
     zeroDec;
+  let collateralAmountUSD = (collateralUSDPrice != zeroDec) ?
+    collateralUSDPrice.times(event.params.investmentAmount.divDecimal(collateralScaleDec)) :
+    zeroDec;
 
   setLiquidity(fpmm as FixedProductMarketMaker, newAmounts, collateralScaleDec, collateralUSDPrice);
   increaseVolume(
@@ -290,7 +295,8 @@ export function handleBuy(event: FPMMBuy): void {
     event.params.buyer.toHexString());
 
   recordTrade(fpmm as FixedProductMarketMaker, 
-    event.params.buyer.toHexString(), event.params.investmentAmount,
+    event.params.buyer.toHexString(),
+    event.params.investmentAmount, collateralAmountUSD,
     event.params.feeAmount, event.params.outcomeIndex,
     event.params.outcomeTokensBought, TRADE_TYPE_BUY,
     event.block.timestamp);
@@ -325,6 +331,9 @@ export function handleSell(event: FPMMSell): void {
   let collateralUSDPrice = ethPerCollateral != null && usdPerEth != null ?
     ethPerCollateral.times(usdPerEth as BigDecimal) :
     zeroDec;
+  let collateralAmountUSD = (collateralUSDPrice != zeroDec) ?
+   collateralUSDPrice.times(event.params.returnAmount.divDecimal(collateralScaleDec)) :
+   zeroDec;
 
   setLiquidity(fpmm as FixedProductMarketMaker, newAmounts, collateralScaleDec, collateralUSDPrice);
   increaseVolume(
@@ -343,7 +352,8 @@ export function handleSell(event: FPMMSell): void {
     event.params.seller.toHexString());
 
   recordTrade(fpmm as FixedProductMarketMaker, 
-    event.params.seller.toHexString(), event.params.returnAmount,
+    event.params.seller.toHexString(),
+    event.params.returnAmount, collateralAmountUSD,
     event.params.feeAmount, event.params.outcomeIndex,
     event.params.outcomeTokensSold, TRADE_TYPE_SELL,
     event.block.timestamp);

--- a/src/utils/fpmm.ts
+++ b/src/utils/fpmm.ts
@@ -166,6 +166,14 @@ export function updateScaledVolumes(
   );
 }
 
+export function calculateLiquidityParameter(outcomeTokenAmounts: BigInt[]): BigInt {
+  let amountsProduct = one;
+  for(let i = 0; i < outcomeTokenAmounts.length; i++) {
+    amountsProduct = amountsProduct.times(outcomeTokenAmounts[i]);
+  }
+  return nthRoot(amountsProduct, outcomeTokenAmounts.length);
+}
+
 export function setLiquidity(
   fpmm: FixedProductMarketMaker,
   outcomeTokenAmounts: BigInt[],
@@ -174,11 +182,7 @@ export function setLiquidity(
 ): void {
   fpmm.outcomeTokenAmounts = outcomeTokenAmounts;
 
-  let amountsProduct = one;
-  for(let i = 0; i < outcomeTokenAmounts.length; i++) {
-    amountsProduct = amountsProduct.times(outcomeTokenAmounts[i]);
-  }
-  let liquidityParameter = nthRoot(amountsProduct, outcomeTokenAmounts.length);
+  let liquidityParameter = calculateLiquidityParameter(outcomeTokenAmounts);
   fpmm.liquidityParameter = liquidityParameter;
   let scaledLiquidityParameter = liquidityParameter.divDecimal(collateralScaleDec);
   fpmm.scaledLiquidityParameter = scaledLiquidityParameter;

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -1,0 +1,24 @@
+import { BigInt } from '@graphprotocol/graph-ts'
+import { zero } from './constants';
+
+export function max(array: BigInt[]): BigInt {
+    let len = array.length
+    let maxValue = zero;
+    while (len--) {
+      if (array[len].gt(maxValue)) {
+        maxValue = array[len];
+      }
+    }
+    return maxValue;
+}
+
+export function min(array: BigInt[]): BigInt {
+    let len = array.length
+    let minValue = BigInt.fromI32(i32.MAX_VALUE);
+    while (len--) {
+      if (array[len].lt(minValue)) {
+        minValue = array[len];
+      }
+    }
+    return minValue;
+}


### PR DESCRIPTION
Add a new `FPMMLiquidity` entity with the record of every
`FPMMFundingAdded` and `FPMMFundingRemoved` events from all
FixedProductMarketMakert contracts.

Add a new `fpmm.calculateLiquidityParameter` method to calculate with the
`nthRoot` the collateral liquidity parameter.

Resolves: #71
