### PR TITLE
Add old and new outcome token marginal prices to FPMMTrade entity

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -210,6 +210,7 @@ type FpmmTrade @entity {
   feeAmount: BigInt!
   outcomeIndex: BigInt!
   outcomeTokensTraded: BigInt!
+  transactionHash: Bytes!
 }
 
 type FpmmLiquidity @entity {
@@ -223,6 +224,7 @@ type FpmmLiquidity @entity {
   sharesAmount: BigInt!
   collateralRemovedFromFeePool: BigInt
   creationTimestamp: BigInt!
+  transactionHash: Bytes!
 }
 
 type Account @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -199,6 +199,8 @@ type FpmmTrade @entity {
   # lifted from fpmm
   title: String
   collateralToken: Bytes!
+  outcomeTokenMarginalPrice: BigDecimal!
+  oldOutcomeTokenMarginalPrice: BigDecimal!
 
   type: TradeType!
   creator: Account!
@@ -220,7 +222,7 @@ type FpmmLiquidity @entity {
   funder: Account!
   sharesAmount: BigInt!
   collateralRemovedFromFeePool: BigInt
-  creationTimestamp: BigInt! 
+  creationTimestamp: BigInt!
 }
 
 type Account @entity {

--- a/src/FixedProductMarketMakerMapping.ts
+++ b/src/FixedProductMarketMakerMapping.ts
@@ -56,8 +56,8 @@ function recordTrade(fpmm: FixedProductMarketMaker,
     fpmmTrade.fpmm = fpmm.id;
     fpmmTrade.title = fpmm.title;
     fpmmTrade.collateralToken = fpmm.collateralToken;
-    fpmmTrade.outcomeTokenMarginalPrice = fpmm.outcomeTokenMarginalPrice;
-    fpmmTrade.oldOutcomeTokenMarginalPrice = fpmm.oldOutcomeTokenMarginalPrice;
+    fpmmTrade.outcomeTokenMarginalPrice = outcomeTokenMarginalPrice;
+    fpmmTrade.oldOutcomeTokenMarginalPrice = oldOutcomeTokenMarginalPrice;
     fpmmTrade.type = tradeType;
     fpmmTrade.creator = traderAddress;
     fpmmTrade.creationTimestamp = creationTimestamp;
@@ -337,7 +337,8 @@ export function handleBuy(event: FPMMBuy): void {
     collateralAmountUSD = collateralUSDPrice.times(event.params.investmentAmount.divDecimal(collateralScaleDec));
   }
 
-  let oldOutcomeTokenMarginalPrice = fpmm.outcomeTokenMarginalPrices[event.params.outcomeIndex.toI32()];
+  let oldOutcomeTokenMarginalPrices = fpmm.outcomeTokenMarginalPrices as Array<BigDecimal>;
+  let oldOutcomeTokenMarginalPrice = (oldOutcomeTokenMarginalPrices != null) ? oldOutcomeTokenMarginalPrices[outcomeIndex] as BigDecimal : zeroDec;
   setLiquidity(fpmm as FixedProductMarketMaker, newAmounts, collateralScaleDec, collateralUSDPrice);
   increaseVolume(
     global,
@@ -350,7 +351,8 @@ export function handleBuy(event: FPMMBuy): void {
   );
 
   fpmm.save();
-  let newOutcomeTokenMarginalPrice = fpmm.outcomeTokenMarginalPrices[event.params.outcomeIndex.toI32()];
+  let newOutcomeTokenMarginalPrices = fpmm.outcomeTokenMarginalPrices as Array<BigDecimal>;
+  let newOutcomeTokenMarginalPrice = (newOutcomeTokenMarginalPrices != null) ? newOutcomeTokenMarginalPrices[outcomeIndex] as BigDecimal : zeroDec;
 
   recordParticipation(fpmm as FixedProductMarketMaker, 
     event.params.buyer.toHexString());
@@ -397,7 +399,8 @@ export function handleSell(event: FPMMSell): void {
     collateralAmountUSD = collateralUSDPrice.times(event.params.returnAmount.divDecimal(collateralScaleDec));
   }
 
-  let oldOutcomeTokenMarginalPrice = fpmm.outcomeTokenMarginalPrices[event.params.outcomeIndex.toI32()];
+  let oldOutcomeTokenMarginalPrices = fpmm.outcomeTokenMarginalPrices as Array<BigDecimal>;
+  let oldOutcomeTokenMarginalPrice = (oldOutcomeTokenMarginalPrices != null) ? oldOutcomeTokenMarginalPrices[outcomeIndex] as BigDecimal : zeroDec;
   setLiquidity(fpmm as FixedProductMarketMaker, newAmounts, collateralScaleDec, collateralUSDPrice);
   increaseVolume(
     global,
@@ -410,7 +413,8 @@ export function handleSell(event: FPMMSell): void {
   );
 
   fpmm.save();
-  let newOutcomeTokenMarginalPrice = fpmm.outcomeTokenMarginalPrices[event.params.outcomeIndex.toI32()];
+  let newOutcomeTokenMarginalPrices = fpmm.outcomeTokenMarginalPrices as Array<BigDecimal>;
+  let newOutcomeTokenMarginalPrice = (newOutcomeTokenMarginalPrices != null) ? newOutcomeTokenMarginalPrices[outcomeIndex] as BigDecimal : zeroDec;
 
   recordParticipation(fpmm as FixedProductMarketMaker, 
     event.params.seller.toHexString());

--- a/src/FixedProductMarketMakerMapping.ts
+++ b/src/FixedProductMarketMakerMapping.ts
@@ -41,6 +41,7 @@ function requireAccount(accountAddress: string): Account | null {
 function recordTrade(fpmm: FixedProductMarketMaker, 
     traderAddress: string,
     collateralAmount: BigInt, collateralAmountUSD: BigDecimal,
+    outcomeTokenMarginalPrice: BigDecimal, oldOutcomeTokenMarginalPrice: BigDecimal,
     feeAmount: BigInt, outcomeIndex: BigInt,
     outcomeTokensTraded: BigInt, tradeType: string,
     creationTimestamp: BigInt): void {
@@ -55,6 +56,8 @@ function recordTrade(fpmm: FixedProductMarketMaker,
     fpmmTrade.fpmm = fpmm.id;
     fpmmTrade.title = fpmm.title;
     fpmmTrade.collateralToken = fpmm.collateralToken;
+    fpmmTrade.outcomeTokenMarginalPrice = fpmm.outcomeTokenMarginalPrice;
+    fpmmTrade.oldOutcomeTokenMarginalPrice = fpmm.oldOutcomeTokenMarginalPrice;
     fpmmTrade.type = tradeType;
     fpmmTrade.creator = traderAddress;
     fpmmTrade.creationTimestamp = creationTimestamp;
@@ -334,6 +337,7 @@ export function handleBuy(event: FPMMBuy): void {
     collateralAmountUSD = collateralUSDPrice.times(event.params.investmentAmount.divDecimal(collateralScaleDec));
   }
 
+  let oldOutcomeTokenMarginalPrice = fpmm.outcomeTokenMarginalPrices[event.params.outcomeIndex.toI32()];
   setLiquidity(fpmm as FixedProductMarketMaker, newAmounts, collateralScaleDec, collateralUSDPrice);
   increaseVolume(
     global,
@@ -346,6 +350,7 @@ export function handleBuy(event: FPMMBuy): void {
   );
 
   fpmm.save();
+  let newOutcomeTokenMarginalPrice = fpmm.outcomeTokenMarginalPrices[event.params.outcomeIndex.toI32()];
 
   recordParticipation(fpmm as FixedProductMarketMaker, 
     event.params.buyer.toHexString());
@@ -353,6 +358,7 @@ export function handleBuy(event: FPMMBuy): void {
   recordTrade(fpmm as FixedProductMarketMaker, 
     event.params.buyer.toHexString(),
     event.params.investmentAmount, collateralAmountUSD,
+    newOutcomeTokenMarginalPrice, oldOutcomeTokenMarginalPrice,
     event.params.feeAmount, event.params.outcomeIndex,
     event.params.outcomeTokensBought, TRADE_TYPE_BUY,
     event.block.timestamp);
@@ -391,6 +397,7 @@ export function handleSell(event: FPMMSell): void {
     collateralAmountUSD = collateralUSDPrice.times(event.params.returnAmount.divDecimal(collateralScaleDec));
   }
 
+  let oldOutcomeTokenMarginalPrice = fpmm.outcomeTokenMarginalPrices[event.params.outcomeIndex.toI32()];
   setLiquidity(fpmm as FixedProductMarketMaker, newAmounts, collateralScaleDec, collateralUSDPrice);
   increaseVolume(
     global,
@@ -403,6 +410,7 @@ export function handleSell(event: FPMMSell): void {
   );
 
   fpmm.save();
+  let newOutcomeTokenMarginalPrice = fpmm.outcomeTokenMarginalPrices[event.params.outcomeIndex.toI32()];
 
   recordParticipation(fpmm as FixedProductMarketMaker, 
     event.params.seller.toHexString());
@@ -410,6 +418,7 @@ export function handleSell(event: FPMMSell): void {
   recordTrade(fpmm as FixedProductMarketMaker, 
     event.params.seller.toHexString(),
     event.params.returnAmount, collateralAmountUSD,
+    newOutcomeTokenMarginalPrice, oldOutcomeTokenMarginalPrice,
     event.params.feeAmount, event.params.outcomeIndex,
     event.params.outcomeTokensSold, TRADE_TYPE_SELL,
     event.block.timestamp);

--- a/src/FixedProductMarketMakerMapping.ts
+++ b/src/FixedProductMarketMakerMapping.ts
@@ -1,4 +1,4 @@
-import { BigInt, log, Address, BigDecimal } from '@graphprotocol/graph-ts'
+import { BigInt, log, Address, BigDecimal, Bytes } from '@graphprotocol/graph-ts'
 
 import {
   FixedProductMarketMaker,
@@ -44,7 +44,8 @@ function recordTrade(fpmm: FixedProductMarketMaker,
     outcomeTokenMarginalPrice: BigDecimal, oldOutcomeTokenMarginalPrice: BigDecimal,
     feeAmount: BigInt, outcomeIndex: BigInt,
     outcomeTokensTraded: BigInt, tradeType: string,
-    creationTimestamp: BigInt): void {
+    creationTimestamp: BigInt,
+    transactionHash: Bytes): void {
   let account = requireAccount(traderAddress);
   account.tradeNonce = account.tradeNonce.plus(BigInt.fromI32(1));
   account.save();
@@ -66,6 +67,7 @@ function recordTrade(fpmm: FixedProductMarketMaker,
     fpmmTrade.feeAmount = feeAmount;
     fpmmTrade.outcomeIndex = outcomeIndex;
     fpmmTrade.outcomeTokensTraded = outcomeTokensTraded;
+    fpmmTrade.transactionHash = transactionHash;
 
     fpmmTrade.save();
   }
@@ -78,7 +80,8 @@ function recordFPMMLiquidity(fpmm: FixedProductMarketMaker,
     funder: string,
     sharesAmount: BigInt,
     collateralRemovedFromFeePool: BigInt,
-    creationTimestamp: BigInt): void {
+    creationTimestamp: BigInt,
+    transactionHash: Bytes): void {
   let account = requireAccount(funder);
   account.tradeNonce = account.tradeNonce.plus(BigInt.fromI32(1));
   account.save();
@@ -91,6 +94,7 @@ function recordFPMMLiquidity(fpmm: FixedProductMarketMaker,
     fpmmLiquidity.type = liquidityType;
     fpmmLiquidity.funder = funder;
     fpmmLiquidity.creationTimestamp = creationTimestamp;
+    fpmmLiquidity.transactionHash = transactionHash;
 
     fpmmLiquidity.outcomeTokenAmounts = outcomeTokenAmounts;
     if (liquidityType === LIQUIDITY_TYPE_ADD) {
@@ -264,7 +268,8 @@ export function handleFundingAdded(event: FPMMFundingAdded): void {
     event.params.funder.toHexString(),
     event.params.sharesMinted,
     BigInt.fromI32(0),
-    event.block.timestamp);
+    event.block.timestamp,
+    event.transaction.hash);
 }
 
 export function handleFundingRemoved(event: FPMMFundingRemoved): void {
@@ -301,7 +306,8 @@ export function handleFundingRemoved(event: FPMMFundingRemoved): void {
     event.params.funder.toHexString(),
     event.params.sharesBurnt,
     event.params.collateralRemovedFromFeePool,
-    event.block.timestamp);
+    event.block.timestamp,
+    event.transaction.hash);
 }
 
 export function handleBuy(event: FPMMBuy): void {
@@ -363,7 +369,8 @@ export function handleBuy(event: FPMMBuy): void {
     newOutcomeTokenMarginalPrice, oldOutcomeTokenMarginalPrice,
     event.params.feeAmount, event.params.outcomeIndex,
     event.params.outcomeTokensBought, TRADE_TYPE_BUY,
-    event.block.timestamp);
+    event.block.timestamp,
+    event.transaction.hash);
 }
 
 export function handleSell(event: FPMMSell): void {
@@ -425,7 +432,8 @@ export function handleSell(event: FPMMSell): void {
     newOutcomeTokenMarginalPrice, oldOutcomeTokenMarginalPrice,
     event.params.feeAmount, event.params.outcomeIndex,
     event.params.outcomeTokensSold, TRADE_TYPE_SELL,
-    event.block.timestamp);
+    event.block.timestamp,
+    event.transaction.hash);
 }
 
 export function handlePoolShareTransfer(event: Transfer): void {


### PR DESCRIPTION
Set the old and new values for the `OutcomeTokenMarginalPrices` of the
selected outcome on the `FPMMBuy` and `FPMMSell` events to store that
values on FPMMTrade entity.

Add `transactionHash` attributes to FPMMTrade and FPMMLiquidity entities.

Resolves: https://github.com/protofire/omen-subgraph/issues/80