### PR TITLE
Add question association on `ConditionPreparation`

### DIFF
--- a/src/ConditionalTokensMapping.template.ts
+++ b/src/ConditionalTokensMapping.template.ts
@@ -10,6 +10,7 @@ export function handleConditionPreparation(event: ConditionPreparation): void {
   let condition = new Condition(event.params.conditionId.toHexString());
   condition.oracle = event.params.oracle;
   condition.questionId = event.params.questionId;
+  condition.question = event.params.questionId.toHexString();
 
   if (event.params.oracle.toHexString() == '{{RealitioProxy.addressLowerCase}}') {
     assignQuestionToCondition(condition, event.params.questionId.toHexString());

--- a/src/ConditionalTokensMapping.template.ts
+++ b/src/ConditionalTokensMapping.template.ts
@@ -10,11 +10,12 @@ export function handleConditionPreparation(event: ConditionPreparation): void {
   let condition = new Condition(event.params.conditionId.toHexString());
   condition.oracle = event.params.oracle;
   condition.questionId = event.params.questionId;
-  condition.question = event.params.questionId.toHexString();
 
   if (event.params.oracle.toHexString() == '{{RealitioProxy.addressLowerCase}}') {
+    log.info('Condition oracle address is RealitioProxy {}', ['{{RealitioProxy.addressLowerCase}}']);
     assignQuestionToCondition(condition, event.params.questionId.toHexString());
   } else if (event.params.oracle.toHexString() == '{{RealitioScalarAdapter.addressLowerCase}}') {
+    log.info('Condition oracle address is RealitioScalarAdapter {}', ['{{RealitioScalarAdapter.addressLowerCase}}']);
     let linkId = event.params.questionId.toHexString();
     let link = ScalarQuestionLink.load(linkId);
     if (link != null) {
@@ -22,6 +23,9 @@ export function handleConditionPreparation(event: ConditionPreparation): void {
       condition.scalarLow = link.scalarLow;
       condition.scalarHigh = link.scalarHigh;
     }
+  } else {
+    log.warning('Condition oracle address {} is not a known Realitio address.', [condition.oracle.toHexString()]);
+    assignQuestionToCondition(condition, event.params.questionId.toHexString());
   }
 
   let global = requireGlobal();


### PR DESCRIPTION
Add the question associated with the Conditon entity on the `ConditionPreparation` event that will create a new Condition.

The Associated question Id comes from the parameter `questionId` and it should be created from the Realitio mapping.

The method `assignQuestionToCondition` does not pass the `condition` object by reference and the `questionId` is not set on the object.