### PR TITLE
Fix duplicated RealitioScalarAdapter config

### DIFF
--- a/networks.json
+++ b/networks.json
@@ -89,16 +89,6 @@
       "transactionHash": "0x07bb34b2e09a899fc7914638b424e2fbd7819401ca5a083c75b55dca47ba83d4"
     }
   },
-  "RealitioScalarAdapter": {
-    "1": {
-      "address": "0xaa548EfBb0972e0c4b9551dcCfb6B787A1B90082",
-      "transactionHash": "0x781e582a3476bd59d35faa6c47164e5e51f0356a6756a7fcc5fbc7a79d4eed58"
-    },
-    "4": {
-      "address": "0x3A4A1EFF11b81d3ecEbc92f1Ce902F2C738867b8",
-      "transactionHash": "0x5fcc9f527246b8992aa38615dd59ac68b448c0dd4377fd2e47deb13915ee64a5"
-    }
-  },
   "DXTokenRegistry": {
     "1": {
       "address": "0x93db90445b76329e9ed96ecd74e76d8fbf2590d8",


### PR DESCRIPTION
Remove the old `RealitioScalarAdapter` addresses from `networks.json`
file.
Setup the new *Rinkeby* Realitio addresses from #97.