### PR TITLE
Reset mainnet arbitration proxy

### DIFF
--- a/networks.json
+++ b/networks.json
@@ -55,8 +55,8 @@
   },
   "RealitioProxy": {
     "1": {
-      "address": "0xaFffbEA35c395e4BD246B4834071D01498151B16",
-      "transactionHash": "0xcca7d3779b8915d4fb743a74fa165247d5571669b4d1b22a2b638a657ab08fc9"
+      "address": "0x0e414d014A77971f4EAA22AB58E6d84D16Ea838E",
+      "transactionHash": "0x8737379f9eb9e8e98aa77b74f46b40122770c96b7e87d85d37d18414166e5d49"
     },
     "4": {
       "address": "0x17174dC1b62add32a1DE477A357e75b0dcDEed6E",


### PR DESCRIPTION
It looks like the mainnet arbitration proxy was not actually updated, and instead I had mistakenly set it as the mainnet counterpart to the xDai arbitration contract