### PR TITLE
Reset all realitio proxies

### DIFF
--- a/networks.json
+++ b/networks.json
@@ -63,12 +63,12 @@
       "transactionHash": "0x02a4080fc1c72e4aae4e970740012315a6cbc9509a8d0b1e683fa6b03c49a79a"
     },
     "77": {
-      "address": "0xd50DdFdDbC069C1D1f7CDA1D8aa4AD8cFb1E9e0F",
-      "transactionHash": "0x4b0b6126c7d4beba5613a2bd2730abea1d3d8d837fd5070e14003f90477f860a"
+      "address": "0x9E6bd63aEbFb2E858B6111cea9C389f7664F7108",
+      "transactionHash": "0x22ec41cd5edc006a86235587a68a06b468c3f6fdb26616bcba3215242987051e"
     },
     "100": {
-      "address": "0x7761D33924bb90129EF56480FC1bD8Da79C8069B",
-      "transactionHash": "0x273e56f1a572766b8f2bf3d7356d9723c4bba1b867a3f922cd3d73ba076f261b"
+      "address": "0xAB16D643bA051C11962DA645f74632d3130c81E2",
+      "transactionHash": "0x68f4745d14daa9b59f872b7f42b3ceeb5e352add42afab7360bb8f5b827f3525"
     }
   },
   "RealitioScalarAdapter": {


### PR DESCRIPTION
It turns out I've actually mistakenly conflated the realitio proxy with the realitio arbitration proxy when they're different things, and the subgraph doesn't currently track the arbitration proxy