### PR TITLE
Remove type on GeneralizedTCRMapping file

### DIFF
--- a/src/GeneralizedTCRMapping.ts
+++ b/src/GeneralizedTCRMapping.ts
@@ -1,7 +1,6 @@
 import { log } from '@graphprotocol/graph-ts';
 import { ItemStatusChange, GeneralizedTCR } from '../generated/GeneralizedTCR/GeneralizedTCR';
 import { FixedProductMarketMaker, KlerosSubmission } from '../generated/schema';
-import { Address } from '../generated/'
 
 function hexStringToLowerCase(input: string): string {
   // Code looks weird? Unfortunately the current version


### PR DESCRIPTION
Remove type on GeneralizedTCRMapping file:
```
import { Address } from '../generated/'
```

Error: 
```
✖ Failed to compile subgraph: Failed to compile data source mapping: Import file 'generated/.ts' not found.
```